### PR TITLE
Fix props for the react lowlight component

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,6 +5,9 @@
 // Copy this file, and add rule overrides as needed.
 {
   "extends": "airbnb/base",
+  "env": {
+    "mocha": true
+  },
 
   /**
    * Overrides to the airbnb rules

--- a/README.md
+++ b/README.md
@@ -7,18 +7,24 @@
 
 import remark from 'remark';
 import reactRenderer from 'remark-react';
-import RemarkLowlight from 'remark-react-lowlight'
+import RemarkLowlight from 'remark-react-lowlight';
 
 import js from 'highlight.js/lib/languages/javascript';
 
+import merge from 'deepmerge';
+import sanitizeGhSchema from 'hast-util-sanitize/lib/github.json';
+
+const schema = merge(sanitizeGhSchema, { attributes: { 'code': ['className'] } });
+
 ...
 {remark().use(reactRenderer, {
+  sanitize: schema,
   remarkReactComponents: {
     code: RemarkLowlight({
       js
     })
   }
-}).process(readme)}
+}).process(readme).contents}
 ...
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,9 +22,14 @@ exports.default = function (languageDefinitions) {
   });
 
   var Code = function Code(_ref) {
-    var className = _ref.className;
+    var _ref$className = _ref.className;
+    var className = _ref$className === undefined ? '' : _ref$className;
     var children = _ref.children;
-    return _react2.default.createElement(_reactLowlight2.default, { language: className.split('-')[1], value: children });
+
+    var language = className.split('-')[1] || '';
+    var value = children[0] || '';
+    var props = { language: language, value: value };
+    return _react2.default.createElement(_reactLowlight2.default, props);
   };
   Code.propTypes = {
     className: _react2.default.PropTypes.string,

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "babel src -d lib",
     "watch": "babel src --watch -d lib",
     "lint": "eslint . --ext .js --ext .jsx",
-    "preversion": "npm run lint && npm run build && git commit --allow-empty -am \"Update lib\""
+    "preversion": "npm run lint && npm run build && git commit --allow-empty -am \"Update lib\"",
+    "test": "mocha --require test/setup.js --compilers js:babel-register"
   },
   "main": "lib/index.js",
   "dependencies": {
@@ -15,11 +16,23 @@
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",
+    "babel-core": "^6.17.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
+    "babel-register": "^6.16.3",
+    "deepmerge": "^1.2.0",
+    "enzyme": "^2.5.1",
     "eslint": "^2.7.0",
     "eslint-config-airbnb": "^6.2.0",
-    "mocha": "^2.4.5"
+    "hast-util-sanitize": "^1.1.0",
+    "highlight.js": "^9.7.0",
+    "jsdom": "^9.8.0",
+    "mocha": "^3.1.2",
+    "react": "^15.3.2",
+    "react-addons-test-utils": "^15.3.2",
+    "react-dom": "^15.3.2",
+    "remark": "^6.0.1",
+    "remark-react": "^3.0.2"
   },
   "peerDependencies": {
     "react": ">= 0.11.2 < 16.0.0"

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -8,9 +8,14 @@ export default (languageDefinitions) => {
     Lowlight.registerLanguage(language, definition);
   });
 
-  const Code = ({ className, children }) => (
-    <Lowlight language={className.split('-')[1]} value={children} />
-  );
+  const Code = ({ className = '', children }) => {
+    const language = className.split('-')[1] || '';
+    const value = children[0] || '';
+    const props = { language, value };
+    return (
+      <Lowlight {...props} />
+    );
+  };
   Code.propTypes = {
     className: React.PropTypes.string,
     children: React.PropTypes.node

--- a/test/example/md-to-react.js
+++ b/test/example/md-to-react.js
@@ -1,0 +1,23 @@
+import remark from 'remark';
+import reactRenderer from 'remark-react';
+
+import merge from 'deepmerge';
+import sanitizeGhSchema from 'hast-util-sanitize/lib/github.json';
+import js from 'highlight.js/lib/languages/javascript';
+
+import RemarkLowlight from '../../lib/index.js';
+
+const mdToReact = (markdown) => {
+  const schema = merge(sanitizeGhSchema, { attributes: { code: ['className'] } });
+  return remark().use(reactRenderer, {
+    sanitize: schema,
+    remarkComponents: {
+      // eslint-disable-next-line new-cap
+      code: RemarkLowlight({
+        js
+      })
+    }
+  }).process(markdown).contents;
+};
+
+export default mdToReact;

--- a/test/md-to-react.spec.js
+++ b/test/md-to-react.spec.js
@@ -1,0 +1,27 @@
+import React from 'react'; // eslint-disable-line no-unused-vars
+import { mount } from 'enzyme';
+import assert from 'assert';
+
+import mdToReact from './example/md-to-react.js';
+
+describe('mdToReact', () => {
+
+  it('render code block element using highlight.js', () => {
+    const codeBlockText = 'function blah(arg1) {\n  console.log(arg1);\n}\nblah(\'blah\');\n';
+    const inputMarkdown = `
+\`\`\`js
+${codeBlockText}
+\`\`\`
+`;
+
+    const actual = mdToReact(inputMarkdown);
+    const wrapper = mount(actual);
+    assert(wrapper.type, 'div');
+    assert(wrapper.text(), codeBlockText);
+    const preWrapper = wrapper.find('pre');
+    assert(
+      preWrapper.contains(<pre><code className="language-js">{codeBlockText}</code></pre>)
+      , true
+    );
+  });
+});

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,13 @@
+import { jsdom } from 'jsdom';
+
+global.document = jsdom('');
+global.window = document.defaultView;
+Object.keys(document.defaultView).forEach(property => {
+  if (typeof global[property] === 'undefined') {
+    global[property] = document.defaultView[property];
+  }
+});
+
+global.navigator = {
+  userAgent: 'node.js'
+};


### PR DESCRIPTION
I fixed 2 points.
1. the difference between props bound from [remark-react-lowlight](https://github.com/bebraw/remark-react-lowlight/blob/11b170187bde9664b7c14353e8ecaa635fb1006f/src/index.jsx#L12) and props of [react-lowlight](https://github.com/rexxars/react-lowlight/blob/bfe01a24f4fa5b83e5d29c3d873137f08cdf904a/src/Lowlight.js#L42-Lundefined)
   - react-lowlight `props.value`'s type must be `string`, but type of `value` bound from remark-react-lowlight was `node`
2. example usage
   - [hast-util-sanitize](https://github.com/wooorm/hast-util-sanitize) removes `<code>`'s `className`, so we should add the `sanitize`'s schema to keep className: **language-blahblah** for syntax highlight.

If you have any time, please review.
Thanks!
