### PR TITLE
Fix errors when a language was not registered

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28,13 +28,14 @@ exports.default = function (languageDefinitions) {
 
     var language = className.split('-')[1] || '';
     var value = children[0] || '';
-    var props = { language: language, value: value, inline: true };
+    var props = { value: value, inline: true };
 
-    return language ? _react2.default.createElement(_reactLowlight2.default, props) : _react2.default.createElement(
-      'code',
-      null,
-      value
-    );
+    if (Object.keys(languageDefinitions).indexOf(language) > -1) {
+      // Include the language only if it was previously registered
+      props.language = language;
+    }
+
+    return _react2.default.createElement(_reactLowlight2.default, props);
   };
   Code.propTypes = {
     className: _react2.default.PropTypes.string,

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -18,7 +18,7 @@ export default (languageDefinitions) => {
       props.language = language;
     }
 
-    return <Lowlight {...props} /> ;
+    return <Lowlight {...props} />;
   };
   Code.propTypes = {
     className: React.PropTypes.string,

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -11,9 +11,14 @@ export default (languageDefinitions) => {
   const Code = ({ className = '', children }) => {
     const language = className.split('-')[1] || '';
     const value = children[0] || '';
-    const props = { language, value, inline: true };
+    const props = { value, inline: true };
 
-    return language ? <Lowlight {...props} /> : <code>{ value }</code>;
+    if (Object.keys(languageDefinitions).indexOf(language) > -1) {
+      // Include the language only if it was previously registered
+      props.language = language;
+    }
+
+    return <Lowlight {...props} /> ;
   };
   Code.propTypes = {
     className: React.PropTypes.string,

--- a/test/example/md-to-react.js
+++ b/test/example/md-to-react.js
@@ -4,6 +4,7 @@ import reactRenderer from 'remark-react';
 import merge from 'deepmerge';
 import sanitizeGhSchema from 'hast-util-sanitize/lib/github.json';
 import js from 'highlight.js/lib/languages/javascript';
+import css from 'highlight.js/lib/languages/css';
 
 import RemarkLowlight from '../../lib';
 
@@ -15,7 +16,8 @@ const mdToReact = (markdown) => {
     remarkReactComponents: {
       // eslint-disable-next-line new-cap
       code: RemarkLowlight({
-        js
+        js,
+        css
       })
     }
   }).processSync(markdown).contents;

--- a/test/md-to-react.spec.js
+++ b/test/md-to-react.spec.js
@@ -19,9 +19,15 @@ ${codeBlockText}
     assert.ok(wrapper.find('code').hasClass('hljs'));
   });
 
-  it('should skip elements without defined language', () => {
-    const markdown = 'foo `bar` baz';
+  it('should not fail if the defined language is not registered', () => {
+    const markdown = '```ruby\na = 1```';
     const wrapper = mount(mdToReact(markdown));
-    assert.ok(wrapper.contains(<code>bar</code>));
+    assert.ok(wrapper.find('code').hasClass('hljs'));
+  });
+
+  it('should guess the language if it is not defined', () => {
+    const markdown = '```.test { height: 1em; }```';
+    const wrapper = mount(mdToReact(markdown));
+    assert.ok(wrapper.find('code').hasClass('hljs') && wrapper.find('code').hasClass('css'));
   });
 });


### PR DESCRIPTION
Hello @bebraw,

I'm using your library with [remark-react](https://github.com/mapbox/remark-react). I found an issue when I try to convert a markdown with a block of code that uses a non-registered language:

```
Uncaught Error: Unknown language: `css` is not registered
    at coreHighlight (http://localhost:3000/static/js/bundle.js:31629:11)
    at High.highlight (http://localhost:3000/static/js/bundle.js:31566:20)
    at Lowlight (http://localhost:3000/static/js/bundle.js:50982:11)
    at http://localhost:3000/static/js/bundle.js:41554:16
```

I believe that this is a pretty common use case because I don't know all the languages the user will use. Also, if the user doesn't specify the language, the block is rendered without trying to guess it. Now, the component always returns a `Lowlight` component so, `highlight.js` can try to guess the language.

What do you think?