### PR TITLE
Fix React deprecation warning - use 'prop-types' package

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -33,5 +33,6 @@
     // http://eslint.org/docs/rules/no-unused-vars.html
     "no-unused-vars": [1, {"vars": "all", "args": "after-used"}],
     "padded-blocks": [0, "always"],
+    "react/jsx-uses-react": 2
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _reactLowlight = require('react-lowlight');
 
 var _reactLowlight2 = _interopRequireDefault(_reactLowlight);
@@ -38,8 +42,8 @@ exports.default = function (languageDefinitions) {
     return _react2.default.createElement(_reactLowlight2.default, props);
   };
   Code.propTypes = {
-    className: _react2.default.PropTypes.string,
-    children: _react2.default.PropTypes.node
+    className: _propTypes2.default.string,
+    children: _propTypes2.default.node
   };
 
   return Code;

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "highlight.js": "^9.10.0",
     "jsdom": "^9.12.0",
     "mocha": "^3.2.0",
+    "prop-types": "^15.5.10",
     "react": "^15.4.2",
     "react-addons-test-utils": "^15.4.2",
     "react-dom": "^15.4.2",
@@ -38,6 +39,7 @@
     "remark-react": "^4.0.0"
   },
   "peerDependencies": {
+    "prop-types": "^15.5.10",
     "react": ">= 0.11.2 < 16.0.0"
   },
   "repository": {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Lowlight from 'react-lowlight';
 
 export default (languageDefinitions) => {
@@ -21,8 +22,8 @@ export default (languageDefinitions) => {
     return <Lowlight {...props} />;
   };
   Code.propTypes = {
-    className: React.PropTypes.string,
-    children: React.PropTypes.node
+    className: PropTypes.string,
+    children: PropTypes.node
   };
 
   return Code;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1531,6 +1531,18 @@ fbjs@^0.8.1, fbjs@^0.8.4:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
+fbjs@^0.8.9:
+  version "0.8.14"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.14.tgz#d1dbe2be254c35a91e09f31f9cd50a40b2a0ed1c"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.9"
+
 figures@^1.3.5:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
@@ -2462,7 +2474,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -2913,6 +2925,13 @@ promise@^7.1.1:
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.1.1.tgz#489654c692616b8aa55b0724fa809bb7db49c5bf"
   dependencies:
     asap "~2.0.3"
+
+prop-types@^15.5.10:
+  version "15.5.10"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
 
 property-information@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
Hi 👋 !
The latest versions of `React` emit a deprecation warning when `React.PropTypes` is used. This PR makes the recommended change to using the standalone `prop-types` package. It also adds `prop-types` as a peer dependency.

Let me know if any changes are needed!

Documentation: https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes.